### PR TITLE
Add an option to override the base_url

### DIFF
--- a/llm_command_r.py
+++ b/llm_command_r.py
@@ -84,6 +84,10 @@ class CohereMessages(llm.Model):
             description="Use web search connector",
             default=False,
         )
+        base_url: Optional[str] = Field(
+            description="API base URL (if not the default Cohere endpoint)",
+            default=None,
+        )
 
     def __init__(self, model_id):
         self.model_id = model_id
@@ -101,7 +105,7 @@ class CohereMessages(llm.Model):
         return chat_history
 
     def execute(self, prompt, stream, response, conversation):
-        client = cohere.Client(self.get_key())
+        client = cohere.Client(self.get_key(), base_url=prompt.options.base_url)
         kwargs = {
             "message": prompt.prompt,
             "model": self.model_id,


### PR DESCRIPTION
Adds an option `-o base_url https://...` to override the endpoint used for Command-R.

This is useful when using the model through a cloud provider or your own deployment (tested this with a deployment on Azure - after deploying Command-R+ through the Azure AI Studio I have an endpoint: `https://....swedencentral.inference.ai.azure.com/v1`).

Ultimately I think this is something that can be managed by `llm` in a standard way, like keys, since most popular models are now available from various cloud providers or as your own deployment (if the weights are available). If you think this is interesting let me know and I don't mind contributing that.